### PR TITLE
feat: add the reference message's URL

### DIFF
--- a/src/exts/core/listener.py
+++ b/src/exts/core/listener.py
@@ -51,6 +51,7 @@ class Listener(Cog):
             embed.set_author(
                 name=resolved.author.name,
                 icon_url=resolved.author.display_avatar.url,
+                url=resolved.jump_url
             )
 
             kwargs["embeds"].append(embed)


### PR DESCRIPTION
When a message is replied to, the embed author will have a redirect URL that leads to the URL of the message that was replied to.

**Has not been tested.**