### PR TITLE
feat: add stickers

### DIFF
--- a/src/exts/core/listener.py
+++ b/src/exts/core/listener.py
@@ -1,5 +1,5 @@
 from cachingutils import cached
-from disnake import Embed, Message
+from disnake import Embed, Message, StickerFormatType
 from disnake.ext.commands import Cog
 from disnake.ext.tasks import loop
 from ormar import NoMatch
@@ -60,6 +60,15 @@ class Listener(Cog):
             embed = Embed()
 
             embed.set_image(url=message.attachments[0].url)
+
+            kwargs["embeds"].append(embed)
+
+        if message.stickers and message.stickers[0].format != StickerFormatType.lottie:
+            sticker = message.stickers[0]
+
+            embed = Embed(title=f"Sticker: `{sticker.name}`")
+
+            embed.set_image(url=sticker.url)
 
             kwargs["embeds"].append(embed)
 


### PR DESCRIPTION
Forwards stickers as images, instead of trying (and failing) to send an empty message.
End result looks like this, not sure about the title but it'd be nice to have some way of telling apart stickers and image attachments:
![image](https://user-images.githubusercontent.com/8530778/183249031-55867861-88b0-4014-9ce0-767a79f09798.png)
